### PR TITLE
SDL GUI: drive SDL from the main thread on macOS

### DIFF
--- a/src/AlphaSim.cpp
+++ b/src/AlphaSim.cpp
@@ -200,6 +200,9 @@
 #include "banner.h"
 
 #include "lockstep.h"
+#include "gui/gui.h"
+
+#include <thread>
 
 #if !defined(ES40_GIT_COMMIT)
 #define ES40_GIT_COMMIT "unknown"
@@ -265,6 +268,8 @@ void segv_handler(int signum)
 #warning "Your compiler isn't configured to support backtraces."
 #endif // __GNUG__
 #endif
+
+static void run_emulator(int argc, char* argv[]);
 
 /**
  * Entry point for the application.
@@ -444,6 +449,43 @@ int main(int argc, char* argv[])
 			profiled_insts = 0;
 		}
 #endif
+		if (bx_gui && bx_gui->requires_main_thread())
+			bx_gui->main_thread_init();
+	}
+	catch (CException& e)
+	{
+		printf("Emulator Failure: %s\n", e.displayText().c_str());
+		if (theSystem)
+		{
+			theSystem->stop_threads();
+			delete theSystem;
+		}
+		return 0;
+	}
+
+	// A GUI that owns main() pumps its event loop there while the emulator,
+	// including its shutdown, runs on a worker thread. Everything the GUI
+	// thread posts back has to keep being dispatched until that worker has
+	// joined the GUI thread, so run_emulator() ends the pump itself.
+	if (bx_gui && bx_gui->requires_main_thread())
+	{
+		std::thread emulator(run_emulator, argc, argv);
+		bx_gui->main_thread_pump();
+		emulator.join();
+	}
+	else
+		run_emulator(argc, argv);
+
+	return 0;
+}
+
+/**
+ * Run the emulator, and clean up after it terminates.
+ **/
+static void run_emulator(int argc, char* argv[])
+{
+	try
+	{
 #if defined(IDB)
 		theSystem->start_threads(); // fix from axpbox commit 9ef3473 
 
@@ -512,5 +554,7 @@ int main(int argc, char* argv[])
 			delete theSystem;
 		}
 	}
-	return 0;
+
+	if (bx_gui)
+		bx_gui->main_thread_stop();
 }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -136,11 +136,13 @@ public:
   virtual void                  mouse_enabled_changed_specific(bool val) = 0;
   virtual void                  exit(void) = 0;
 
-  // Some GUI backends must drive the windowing system from the thread that
-  // called main() (SDL on macOS refuses to work anywhere else). A backend that
+  // Some GUI backends drive the windowing system from the thread that called
+  // main() (the SDL backend does so on every platform). A backend that
   // returns true here gets main_thread_init()/main_thread_pump() called from
   // there, and the emulator itself runs on a worker thread; main_thread_stop()
-  // ends the pump once that worker is completely done.
+  // ends the pump once that worker is completely done. Legacy backends that
+  // return false keep the old model: the emulator owns main() and the GUI is
+  // driven entirely from the VGA card's thread.
   virtual bool                  requires_main_thread() { return false; }
   virtual void                  main_thread_init() {}
   virtual void                  main_thread_pump() {}

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -136,6 +136,16 @@ public:
   virtual void                  mouse_enabled_changed_specific(bool val) = 0;
   virtual void                  exit(void) = 0;
 
+  // Some GUI backends must drive the windowing system from the thread that
+  // called main() (SDL on macOS refuses to work anywhere else). A backend that
+  // returns true here gets main_thread_init()/main_thread_pump() called from
+  // there, and the emulator itself runs on a worker thread; main_thread_stop()
+  // ends the pump once that worker is completely done.
+  virtual bool                  requires_main_thread() { return false; }
+  virtual void                  main_thread_init() {}
+  virtual void                  main_thread_pump() {}
+  virtual void                  main_thread_stop() {}
+
   virtual u32                   get_sighandler_mask() { return 0; }
   virtual void                  sighandler(int sig) {}
   virtual void                  beep_on(float frequency);

--- a/src/gui/sdl.cpp
+++ b/src/gui/sdl.cpp
@@ -209,8 +209,13 @@ static SDL_Window*   sdl_window = NULL;
 static SDL_Renderer* sdl_renderer = NULL;
 static SDL_Texture*  sdl_texture = NULL;
 
-/// Set while main() is pumping SDL events on our behalf (see requires_main_thread).
-static std::atomic<bool> sdl_main_thread_pumping(false);
+/// Set once main() has taken ownership of SDL and is driving main_thread_pump()
+/// on our behalf, so on_main_thread() must bounce SDL calls across to it.
+static std::atomic<bool> sdl_main_thread_owns_sdl(false);
+
+/// How long main_thread_pump() blocks waiting for work before looping. Only
+/// caps how quickly it notices main_thread_stop(); callbacks wake it at once.
+static const int sdl_pump_idle_ms = 10;
 
 /**
  * Run fn on the thread that called main().
@@ -226,7 +231,7 @@ static std::atomic<bool> sdl_main_thread_pumping(false);
 template <typename F>
 static void on_main_thread(F fn)
 {
-	if (!sdl_main_thread_pumping.load(std::memory_order_acquire) || SDL_IsMainThread())
+	if (!sdl_main_thread_owns_sdl.load(std::memory_order_acquire) || SDL_IsMainThread())
 	{
 		fn();
 		return;
@@ -266,23 +271,32 @@ void bx_sdl_gui_c::main_thread_init()
 	if (!SDL_Init(SDL_INIT_VIDEO))
 		FAILURE_1(SDL, "Unable to initialize SDL3 video subsystem: %s", SDL_GetError());
 
-	sdl_main_thread_pumping.store(true, std::memory_order_release);
+	sdl_main_thread_owns_sdl.store(true, std::memory_order_release);
 }
 
 void bx_sdl_gui_c::main_thread_pump()
 {
 	// Collect OS events into SDL's queue and dispatch whatever the GUI thread
-	// posted with on_main_thread(). handle_events() drains the queue itself.
-	while (sdl_main_thread_pumping.load(std::memory_order_acquire))
+	// posted with on_main_thread(). handle_events() drains the queue itself,
+	// so the wait is passed NULL and leaves the events where they are.
+	//
+	// SDL_PumpEvents() is what runs the queued on_main_thread() callbacks, so
+	// it has to happen every time round: SDL_WaitEventTimeout() returns early
+	// without pumping while the queue is non-empty, and waiting on that alone
+	// would hang any thread blocked in on_main_thread(). With an empty queue
+	// it sleeps until a posted callback or an OS event wakes it, which keeps
+	// the loop off the CPU without adding latency to the GUI thread.
+	while (sdl_main_thread_owns_sdl.load(std::memory_order_acquire))
 	{
 		SDL_PumpEvents();
-		SDL_Delay(1);
+		if (SDL_WaitEventTimeout(NULL, sdl_pump_idle_ms))
+			SDL_Delay(1);  // queue not drained yet; let the GUI thread catch up
 	}
 }
 
 void bx_sdl_gui_c::main_thread_stop()
 {
-	sdl_main_thread_pumping.store(false, std::memory_order_release);
+	sdl_main_thread_owns_sdl.store(false, std::memory_order_release);
 }
 
 SDL_Event           sdl_event;

--- a/src/gui/sdl.cpp
+++ b/src/gui/sdl.cpp
@@ -95,7 +95,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <atomic>
 #include <cctype>
+#include <exception>
 #include <string>
 #include <SDL3/SDL.h>
 
@@ -149,6 +151,10 @@ public:
 	virtual			u8* graphics_tile_get(unsigned x, unsigned y, unsigned* w, unsigned* h) override;
 	virtual void    graphics_tile_update_in_place(unsigned x, unsigned y, unsigned w, unsigned h) override;
 	void			graphics_frame_update(const u32* pixels, unsigned w, unsigned h) override;
+	virtual bool    requires_main_thread() override;
+	virtual void    main_thread_init() override;
+	virtual void    main_thread_pump() override;
+	virtual void    main_thread_stop() override;
 private:
 	CConfigurator* myCfg;
 	unsigned int   vid_scale = 0;
@@ -168,6 +174,16 @@ private:
 	u32            guest_key_by_scancode[SDL_SCANCODE_COUNT] = {};
 	bool           guest_key_pressed[SDL_SCANCODE_COUNT] = {};
 	bool           swallowed_hotkey_releases[SDL_SCANCODE_COUNT] = {};
+	// Bodies of the public entry points above; always executed on the thread
+	// that owns the SDL window (see on_main_thread).
+	void           specific_init_impl(unsigned x_tilesize, unsigned y_tilesize);
+	void           handle_events_impl();
+	void           clear_screen_impl();
+	void           dimension_update_impl(unsigned x, unsigned y, unsigned fheight,
+		unsigned fwidth, unsigned bpp);
+	void           graphics_frame_update_impl(const u32* pixels, unsigned w, unsigned h);
+	void           mouse_enabled_changed_specific_impl(bool val);
+	void           exit_impl();
 	void           reset_window_size();
 	void           adjust_window_scale(int delta);
 	void           load_hotkeys();
@@ -193,6 +209,81 @@ static SDL_Window*   sdl_window = NULL;
 static SDL_Renderer* sdl_renderer = NULL;
 static SDL_Texture*  sdl_texture = NULL;
 
+/// Set while main() is pumping SDL events on our behalf (see requires_main_thread).
+static std::atomic<bool> sdl_main_thread_pumping(false);
+
+/**
+ * Run fn on the thread that called main().
+ *
+ * SDL wants the video subsystem, the window and the event pump all touched
+ * from that one thread, and macOS enforces it. The emulator drives the GUI
+ * from the VGA card's thread instead, so every SDL call made from there is
+ * bounced across with SDL_RunOnMainThread(). Exceptions (FAILURE_*) must not
+ * escape into SDL's C event loop, so they are caught and rethrown on the
+ * calling thread. On platforms that keep the old threading model this is a
+ * plain inline call.
+ **/
+template <typename F>
+static void on_main_thread(F fn)
+{
+	if (!sdl_main_thread_pumping.load(std::memory_order_acquire) || SDL_IsMainThread())
+	{
+		fn();
+		return;
+	}
+
+	struct SCall
+	{
+		F* fn;
+		std::exception_ptr error;
+	} call = { &fn, nullptr };
+
+	if (!SDL_RunOnMainThread([](void* p)
+		{
+			SCall* c = static_cast<SCall*>(p);
+			try { (*c->fn)(); }
+			catch (...) { c->error = std::current_exception(); }
+		}, &call, true))
+	{
+		FAILURE_1(SDL, "Unable to reach the SDL main thread: %s", SDL_GetError());
+	}
+
+	if (call.error)
+		std::rethrow_exception(call.error);
+}
+
+bool bx_sdl_gui_c::requires_main_thread()
+{
+#if defined(__APPLE__)
+	return true;
+#else
+	return false;
+#endif
+}
+
+void bx_sdl_gui_c::main_thread_init()
+{
+	if (!SDL_Init(SDL_INIT_VIDEO))
+		FAILURE_1(SDL, "Unable to initialize SDL3 video subsystem: %s", SDL_GetError());
+
+	sdl_main_thread_pumping.store(true, std::memory_order_release);
+}
+
+void bx_sdl_gui_c::main_thread_pump()
+{
+	// Collect OS events into SDL's queue and dispatch whatever the GUI thread
+	// posted with on_main_thread(). handle_events() drains the queue itself.
+	while (sdl_main_thread_pumping.load(std::memory_order_acquire))
+	{
+		SDL_PumpEvents();
+		SDL_Delay(1);
+	}
+}
+
+void bx_sdl_gui_c::main_thread_stop()
+{
+	sdl_main_thread_pumping.store(false, std::memory_order_release);
+}
 
 SDL_Event           sdl_event;
 int                 sdl_grab = 0;
@@ -476,7 +567,13 @@ void bx_sdl_gui_c::build_window_titles()
 
 void bx_sdl_gui_c::specific_init(unsigned x_tilesize, unsigned y_tilesize)
 {
-	if (!SDL_Init(SDL_INIT_VIDEO))
+	on_main_thread([&] { specific_init_impl(x_tilesize, y_tilesize); });
+}
+
+void bx_sdl_gui_c::specific_init_impl(unsigned x_tilesize, unsigned y_tilesize)
+{
+	// Already done by main_thread_init() where the GUI owns main().
+	if (!SDL_WasInit(SDL_INIT_VIDEO) && !SDL_Init(SDL_INIT_VIDEO))
 	{
 		FAILURE_1(SDL, "Unable to initialize SDL3 video subsystem: %s", SDL_GetError());
 	}
@@ -515,6 +612,11 @@ void bx_sdl_gui_c::specific_init(unsigned x_tilesize, unsigned y_tilesize)
 }
 
 void bx_sdl_gui_c::graphics_frame_update(const u32* pixels, unsigned width, unsigned height)
+{
+	on_main_thread([&] { graphics_frame_update_impl(pixels, width, height); });
+}
+
+void bx_sdl_gui_c::graphics_frame_update_impl(const u32* pixels, unsigned width, unsigned height)
 {
 	if (!sdl_texture || !sdl_renderer)
 		return;
@@ -766,6 +868,11 @@ void bx_sdl_gui_c::send_guest_ctrl_alt_delete()
 }
 
 void bx_sdl_gui_c::handle_events(void)
+{
+	on_main_thread([&] { handle_events_impl(); });
+}
+
+void bx_sdl_gui_c::handle_events_impl(void)
 {
 	u32 key_event;
 
@@ -1055,6 +1162,11 @@ void bx_sdl_gui_c::flush(void)
  **/
 void bx_sdl_gui_c::clear_screen(void)
 {
+	on_main_thread([&] { clear_screen_impl(); });
+}
+
+void bx_sdl_gui_c::clear_screen_impl(void)
+{
 	if (!sdl_renderer)
 		return;
 
@@ -1075,6 +1187,12 @@ bool bx_sdl_gui_c::palette_change(unsigned index, unsigned red, unsigned green,
 }
 
 void bx_sdl_gui_c::dimension_update(unsigned x, unsigned y, unsigned fheight,
+	unsigned fwidth, unsigned bpp)
+{
+	on_main_thread([&] { dimension_update_impl(x, y, fheight, fwidth, bpp); });
+}
+
+void bx_sdl_gui_c::dimension_update_impl(unsigned x, unsigned y, unsigned fheight,
 	unsigned fwidth, unsigned bpp)
 {
 	SDL_DisplayID display;
@@ -1198,6 +1316,11 @@ void bx_sdl_gui_c::adjust_window_scale(int delta)
 
 void bx_sdl_gui_c::mouse_enabled_changed_specific(bool val)
 {
+	on_main_thread([&] { mouse_enabled_changed_specific_impl(val); });
+}
+
+void bx_sdl_gui_c::mouse_enabled_changed_specific_impl(bool val)
+{
 	if (val)
 	{
 		SDL_HideCursor();
@@ -1223,6 +1346,11 @@ void bx_sdl_gui_c::mouse_enabled_changed_specific(bool val)
 }
 
 void bx_sdl_gui_c::exit(void)
+{
+	on_main_thread([&] { exit_impl(); });
+}
+
+void bx_sdl_gui_c::exit_impl(void)
 {
 	sdl_media_shutdown();
 	if (sdl_texture) {

--- a/src/gui/sdl.cpp
+++ b/src/gui/sdl.cpp
@@ -221,12 +221,13 @@ static const int sdl_pump_idle_ms = 10;
  * Run fn on the thread that called main().
  *
  * SDL wants the video subsystem, the window and the event pump all touched
- * from that one thread, and macOS enforces it. The emulator drives the GUI
- * from the VGA card's thread instead, so every SDL call made from there is
- * bounced across with SDL_RunOnMainThread(). Exceptions (FAILURE_*) must not
- * escape into SDL's C event loop, so they are caught and rethrown on the
- * calling thread. On platforms that keep the old threading model this is a
- * plain inline call.
+ * from that one thread. The emulator drives the GUI from the VGA card's
+ * thread instead, so every SDL call made from there is bounced across with
+ * SDL_RunOnMainThread(). Exceptions (FAILURE_*) must not escape into SDL's
+ * C event loop, so they are caught and rethrown on the calling thread. The
+ * inline path only covers calls made before main() takes ownership and
+ * calls that already run on the main thread (e.g. from within a bounced
+ * callback).
  **/
 template <typename F>
 static void on_main_thread(F fn)
@@ -259,11 +260,10 @@ static void on_main_thread(F fn)
 
 bool bx_sdl_gui_c::requires_main_thread()
 {
-#if defined(__APPLE__)
+	// SDL wants the video subsystem, windows and event pump driven from the
+	// thread that called main() on every platform; macOS merely enforces it.
+	// Claim main() unconditionally so all platforms share one threading model.
 	return true;
-#else
-	return false;
-#endif
 }
 
 void bx_sdl_gui_c::main_thread_init()
@@ -586,7 +586,8 @@ void bx_sdl_gui_c::specific_init(unsigned x_tilesize, unsigned y_tilesize)
 
 void bx_sdl_gui_c::specific_init_impl(unsigned x_tilesize, unsigned y_tilesize)
 {
-	// Already done by main_thread_init() where the GUI owns main().
+	// main_thread_init() has already done this; kept as a fallback so the
+	// backend still works if it ever runs without claiming main().
 	if (!SDL_WasInit(SDL_INIT_VIDEO) && !SDL_Init(SDL_INIT_VIDEO))
 	{
 		FAILURE_1(SDL, "Unable to initialize SDL3 video subsystem: %s", SDL_GetError());


### PR DESCRIPTION
Fixes #97. Cocoa only allows `SDL_Init(SDL_INIT_VIDEO)`, window creation and event pumping on the thread that called `main()`, so the S3Trio64 thread's init fails with "No available video device" and the thread dies before SRM starts.

`bx_gui_c` gains `requires_main_thread()` plus `main_thread_init/pump/stop()`. A backend that claims `main()` gets the emulator (and its shutdown, which has to join the GUI thread while the pump is still alive) moved to a worker thread; the SDL backend claims it on Apple only and bounces its SDL-touching methods across with `SDL_RunOnMainThread`, rethrowing `FAILURE_*` on the caller so exceptions never unwind through SDL's event loop. Everywhere else `requires_main_thread()` is false, every dispatch is a direct call and the threading model is unchanged -- widening it to all SDL builds is a one-line change to that predicate if you would rather be uniform.

Tested on macOS 15 / arm64, SDL 3.4.10, interpreter build: SRM V7.3-1 boots to `P00>>>` in the window, keyboard reaches the guest, the Ctrl+F11 media popup opens, Ctrl-C shuts down with flash/DPR/TOY saved, and closing the window exits without hanging. Closing the window still reports "S3 thread has died" and skips the state save, which is pre-existing on every platform and left alone here.
