### PR TITLE
DEC21143: wake NIC service thread on tap-fd readability

### DIFF
--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -552,8 +552,43 @@ void CDEC21143::start_threads()
 		printf(" %s", myThread->getName().c_str());
 		StopThread = false;
 		myThread->start(*this);
+#if !defined(_WIN32)
+		/* Wake the service thread on packet arrival; otherwise inbound
+		 * packets wait out the 10 ms tryWait window (~5 ms avg added). */
+		if (net_backend && net_backend->get_wait_fd() >= 0 &&
+			!rx_wake_thread.joinable())
+			rx_wake_thread = std::thread(&CDEC21143::rx_wake_loop, this);
+#endif
 	}
 }
+
+#if !defined(_WIN32)
+#include <poll.h>
+#include <unistd.h>
+
+void CDEC21143::rx_wake_loop()
+{
+	struct pollfd pfd;
+	pfd.fd = net_backend->get_wait_fd();
+	pfd.events = POLLIN;
+
+	while (!StopThread)
+	{
+		int r = poll(&pfd, 1, 250);
+		if (StopThread)
+			break;
+		if (r > 0 && (pfd.revents & (POLLIN | POLLERR | POLLHUP)))
+		{
+			mySemaphore.tryWait(0);
+			mySemaphore.set();
+
+			/* Let the service thread drain the fd; avoids a
+			 * level-triggered spin. */
+			usleep(500);
+		}
+	}
+}
+#endif
 
 void CDEC21143::stop_threads()
 {
@@ -567,6 +602,10 @@ void CDEC21143::stop_threads()
 		delete myThread;
 		myThread = 0;
 	}
+#if !defined(_WIN32)
+	if (rx_wake_thread.joinable())
+		rx_wake_thread.join();
+#endif
 }
 
 /**

--- a/src/DEC21143.h
+++ b/src/DEC21143.h
@@ -108,6 +108,10 @@
    *  - Tru64 Device Driver Kit Version 2 (Ethernet sample = tu driver!) [T64]. (http://h30097.www3.hp.com/docs/dev_doc/DOCUMENTATION/HTML/dev_docs_r2.html)
    *  .
    **/
+#if !defined(_WIN32)
+#include <thread>
+#endif
+
 class CDEC21143 : public CPCIDevice, public CRunnable
 {
 public:
@@ -136,6 +140,10 @@ private:
   static int  nic_num;
 
   CThread* myThread;
+#if !defined(_WIN32)
+  std::thread rx_wake_thread;
+  void rx_wake_loop();
+#endif
   bool                StopThread;
   CSemaphore          mySemaphore;
 

--- a/src/NetworkBackend.h
+++ b/src/NetworkBackend.h
@@ -89,6 +89,12 @@ public:
 	                        bool inverse) = 0;
 
 	/**
+	 * A descriptor that becomes readable when a packet is waiting, or -1
+	 * if the backend has no pollable handle.
+	 **/
+	virtual int get_wait_fd() { return -1; }
+
+	/**
 	 * Close the backend and release any resources (file descriptors,
 	 * library handles, created interfaces, ...).
 	 **/

--- a/src/NetworkTap.h
+++ b/src/NetworkTap.h
@@ -52,6 +52,7 @@ public:
 	                        bool promiscuous, bool receive_all,
 	                        bool pass_multicast, bool inverse);
 	virtual void close();
+	virtual int  get_wait_fd() { return tap_fd; }
 
 private:
 	int  tap_fd;


### PR DESCRIPTION
Inbound packets wait out the remainder of the 10 ms `mySemaphore.tryWait` window in the NIC service loop — guest-driven events (CSR writes, TX kicks) signal the semaphore, but nothing wakes it for host->guest RX.

Adds `CNetworkBackend::get_wait_fd()` (default -1) and a POSIX watcher thread in `CDEC21143` that polls the tap fd and signals the existing semaphore, with a 500 us anti-spin nap.

- Measured on a NetBSD/alpha guest: ping avg 7.4 -> 2.9 ms
- Idle cost unchanged (~10%); the watcher blocks in `poll`
- Rebased on v0.83 and re-run tonight: Tru64 5.1B-4 and OpenVMS Alpha 8.4 both boot clean over TAP

Not tested:

- Windows — guarded out entirely with `#if !defined(_WIN32)`
- pcap backends — `get_wait_fd()` returns -1, so behaviour is unchanged
- Sustained throughput; this was measured for latency, not bandwidth

**Filed by Claude Opus 5 on Scott's behalf.**